### PR TITLE
機能追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,8 +78,9 @@ class App(ctk.CTk):
                 sys.exit()
 
     def uninstall(self):
-        subprocess.run("start unins000.exe", shell=True)
-        sys.exit()
+        cp = subprocess.run("start unins000.exe", shell=True)
+        if cp.returncode == 0:
+            sys.exit()
 
     # メニューバーを追加
     def create_menu(self):

--- a/main.py
+++ b/main.py
@@ -21,7 +21,6 @@ from win11toast import toast
 
 class App(ctk.CTk):
     config = configparser.ConfigParser(interpolation=None)
-    ini_path = "config.ini"
 
     def __init__(self):
         super().__init__()
@@ -38,6 +37,7 @@ class App(ctk.CTk):
         self.title("yt-dlp_GUI " + this_version)
         self.geometry("900x300")
         self.iconbitmap("icon.ico")
+        self.ini_path = "config.ini"
 
         self.create_menu()
         self.read_config()
@@ -146,9 +146,16 @@ class App(ctk.CTk):
         self.destroy()
 
     def load_option(self):
-        self.var_chk_audio.set(self.config["Option"]["download_audio"])
-        self.var_chk_thumbnail.set(self.config["Option"]["embed_thumbnail"])
-        self.audio_extension.set(self.config["Option"]["audio_extension"])
+        try:
+            self.var_chk_audio.set(self.config["Option"]["download_audio"])
+            self.var_chk_thumbnail.set(self.config["Option"]["embed_thumbnail"])
+            self.audio_extension.set(self.config["Option"]["audio_extension"])
+        except KeyError as error_message:
+            a = str(error_message)
+            with open(self.ini_path, "w") as f:
+                self.config["Option"][a[1:-1]] = ""
+                self.config.write(f)
+
 
     def init_config(self):
         with open(self.ini_path, "w") as f:

--- a/main.py
+++ b/main.py
@@ -68,13 +68,14 @@ class App(ctk.CTk):
                     "start https://github.com/okata-t/yt-dlp_GUI/releases/latest",
                     shell=True,
                 )
+                sys.exit()
             elif msg.get() == "ダウンロード":
                 subprocess.run(
                     "start https://github.com/okata-t/yt-dlp_GUI/releases/latest/"
                     + "download/yt-dlp_GUI_Setup.exe",
                     shell=True,
                 )
-            sys.exit()
+                sys.exit()
 
     def uninstall(self):
         subprocess.run("start unins000.exe", shell=True)

--- a/main.py
+++ b/main.py
@@ -362,7 +362,7 @@ class App(ctk.CTk):
 
         if download_audio:
             self.opt["postprocessors"].append(
-                {"key": "FFmpegExtractAudio", "preferredcodec": self.combobox_1.get()}
+                {"key": "FFmpegExtractAudio", "preferredcodec": self.audio_extension.get()}
             )
             self.opt["format"] = "bestaudio/best"
 

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from win11toast import toast
 
 class App(ctk.CTk):
     config = configparser.ConfigParser(interpolation=None)
+    ini_path = "config.ini"
 
     def __init__(self):
         super().__init__()
@@ -37,7 +38,6 @@ class App(ctk.CTk):
         self.title("yt-dlp_GUI " + this_version)
         self.geometry("900x300")
         self.iconbitmap("icon.ico")
-        self.ini_path = "config.ini"
 
         self.create_menu()
         self.read_config()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import configparser
 import datetime
 import math
 import os
+import sys
 import subprocess
 import threading
 import tkinter as tk
@@ -10,6 +11,7 @@ from tkinter import filedialog
 import CTkMenuBar
 import CTkMessagebox
 import customtkinter as ctk
+import darkdetect
 import pyperclip
 import requests
 import yt_dlp
@@ -23,6 +25,8 @@ class App(ctk.CTk):
 
     def __init__(self):
         super().__init__()
+
+        self.color_mode = darkdetect.theme()
 
         ver = configparser.ConfigParser()
         ver.read("version.ini", encoding="shift-jis")
@@ -70,18 +74,30 @@ class App(ctk.CTk):
                     + "download/yt-dlp_GUI_Setup.exe",
                     shell=True,
                 )
+            sys.exit()
+
+    def uninstall(self):
+        subprocess.run("start unins000.exe", shell=True)
+        sys.exit()
 
     # メニューバーを追加
-
     def create_menu(self):
-        menu = CTkMenuBar.CTkMenuBar(self)
+        if self.color_mode == "Dark":
+            self.color = "#242424"
+        else:
+            self.color = "#EBEBEB"
+        menu = CTkMenuBar.CTkMenuBar(self, bg_color=self.color)
         self.pack_propagate(0)
         # File menu
-        file_menu = menu.add_cascade("開く")
+        file_menu = menu.add_cascade("オプション", font=self.fonts)
         file_dropdown = CTkMenuBar.CustomDropdownMenu(file_menu, font=self.fonts)
         file_dropdown.add_option(
             "YouTubeを開く",
             command=lambda: subprocess.run("start https://youtube.com", shell=True),
+        )
+        file_dropdown.add_option(
+            "アンインストール",
+            command=lambda: self.uninstall(),
         )
         file_dropdown.add_separator()
 

--- a/main.py
+++ b/main.py
@@ -178,6 +178,7 @@ class App(ctk.CTk):
     def thumbnail_selected(self):
         if self.var_chk_thumbnail.get():
             self.var_chk_audio.set("False")
+            self.audio_extension.configure(state="disabled")
 
     def setup(self):
         self.toplevel_window = None

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ class App(ctk.CTk):
         self.setup()
         self.load_option()
         self.check_version(this_version)
+        self.audio_selected()
 
     def check_version(self, this_version):
 
@@ -140,12 +141,14 @@ class App(ctk.CTk):
             self.config["Option"] = {}
             self.config["Option"]["download_audio"] = str(self.chk_audio.get())
             self.config["Option"]["embed_thumbnail"] = str(self.chk_thumbnail.get())
+            self.config["Option"]["audio_extension"] = str(self.audio_extension.get())
             self.config.write(f)
         self.destroy()
 
     def load_option(self):
         self.var_chk_audio.set(self.config["Option"]["download_audio"])
         self.var_chk_thumbnail.set(self.config["Option"]["embed_thumbnail"])
+        self.audio_extension.set(self.config["Option"]["audio_extension"])
 
     def init_config(self):
         with open(self.ini_path, "w") as f:
@@ -155,7 +158,14 @@ class App(ctk.CTk):
             self.config["Option"] = {}
             self.config["Option"]["download_audio"] = "0"
             self.config["Option"]["embed_thumbnail"] = "0"
+            self.config["Option"]["audio_extension"] = "mp3"
             self.config.write(f)
+
+    def audio_selected(self):
+        if self.var_chk_audio.get():
+            self.audio_extension.configure(state="normal")
+        else:
+            self.audio_extension.configure(state="disabled")
 
     def setup(self):
         self.toplevel_window = None
@@ -267,6 +277,7 @@ class App(ctk.CTk):
             self.frame_option,
             text="音声のみダウンロード",
             font=self.fonts,
+            command=self.audio_selected,
             variable=self.var_chk_audio,
         )
         self.chk_audio.grid(row=0, column=0, padx=10, pady=10, sticky="w")
@@ -279,6 +290,17 @@ class App(ctk.CTk):
             variable=self.var_chk_thumbnail,
         )
         self.chk_thumbnail.grid(row=1, column=0, padx=10, pady=10, sticky="w")
+
+        dict_file = ["mp3", "wav", "m4a", "opus"]
+
+        self.var_chk_file = ctk.BooleanVar()
+        self.audio_extension = ctk.CTkComboBox(
+            self.frame_option,
+            values=list(dict_file),
+            font=self.fonts,
+            width=100
+        )
+        self.audio_extension.grid(row=2, column=0, padx=10, pady=10, sticky="w")
 
     def paste(self):
         clip_text = pyperclip.paste()
@@ -327,7 +349,7 @@ class App(ctk.CTk):
 
         if download_audio:
             self.opt["postprocessors"].append(
-                {"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}
+                {"key": "FFmpegExtractAudio", "preferredcodec": self.combobox_1.get()}
             )
             self.opt["format"] = "bestaudio/best"
 

--- a/main.py
+++ b/main.py
@@ -164,8 +164,13 @@ class App(ctk.CTk):
     def audio_selected(self):
         if self.var_chk_audio.get():
             self.audio_extension.configure(state="normal")
+            self.var_chk_thumbnail.set("False")
         else:
             self.audio_extension.configure(state="disabled")
+
+    def thumbnail_selected(self):
+        if self.var_chk_thumbnail.get():
+            self.var_chk_audio.set("False")
 
     def setup(self):
         self.toplevel_window = None
@@ -287,6 +292,7 @@ class App(ctk.CTk):
             self.frame_option,
             text="サムネイルを埋め込む",
             font=self.fonts,
+            command=self.thumbnail_selected,
             variable=self.var_chk_thumbnail,
         )
         self.chk_thumbnail.grid(row=1, column=0, padx=10, pady=10, sticky="w")


### PR DESCRIPTION
修正・改善箇所

- メニューバーのフォント・文字を改善
- メニューバーの背景色がテーマに合わせて変化する
- アップデート確認後、アプリが起動しないように修正
- メニューバーにアプリのアンインストール機能を追加
- アンインストール機能の軽微な修正
- 音声の拡張子を選択する機能
- サムネイルと音声のチェックボックスを同時に選択できないように修正
- 前バージョンのconfig.iniが残っているとエラーになる問題を修正


アンインストール機能は、main.pyをexeにコンパイルしてインストールした場所に置くか、main.pyのある場所に「unins000.exe」、「unins000.dat」を配置しないと動作確認できない
自分の環境では動作確認できた

拡張子選択のコンボボックスは、以下リンクを参考にすれば、音声DLと動画DLのときでコンボボックス内の拡張子を入れ替えるようにも出来る
ただ、動画の拡張子形式の変更方法が分からなかったから、その辺りは触ってない
https://qiita.com/hajime-f/items/607183684b2d532e1ed7