### PR TITLE
リリースノート確認機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ theme.json
 color.ini
 msgfmt.py
 pygettext.py
+scraping.py
+scraping_old.py
+log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,4 @@ theme.json
 color.ini
 msgfmt.py
 pygettext.py
-scraping.py
-scraping_old.py
 log.txt

--- a/language.ini
+++ b/language.ini
@@ -1,0 +1,294 @@
+[EN]
+#Change_Language_MessageBox
+CLM_title = apply changes
+CLM_message = The app must be restarted for the changes to take effect
+CLM_main_message = Would you like to restart?
+CLM_option1 = cancel
+CLM_option2 = restart
+
+#Update_MessageBox
+UpM_title = update
+UpM_message = new version：
+UpM_main_message = Would you like to download?
+UpM_option1 = cancel
+UpM_option2 = download
+UpM_option3 = open GitHub
+
+#Uninstall_MessageBox
+UnM_title = uninstall
+UnM_message = Do you really want to uninstall?
+UnM_option1 = cancel
+UnM_option2 = uninstall
+
+#Menu_Bar
+MB_option = option
+MB_cookie = Cookie
+MB_cookie_none = none
+MB_language = language
+
+#ここからは基本的に変更しないでください
+MB_lang_EN = English
+MB_lang_JP = 日本語
+MB_lang_KR =
+#ここまでは基本的に変更しないでください
+
+MB_view = view
+MB_theme = theme
+MB_theme_system = system(Menubar reflects on restart)
+MB_theme_dark = dark
+MB_theme_light = light
+MB_theme_edit = open theme editor
+
+MB_link = open links
+MB_link_niconico = Niconico
+
+MB_beta = beta feature
+MB_quickmode = quick mode
+
+MB_others = others
+MB_uninstall = uninstall
+
+#widget
+w_paste = paste
+#SelectとSpecifyのどっちがいいか分からない
+w_savefolder = Specify a folder to save
+w_browse = browse folder
+w_edit = edit
+w_save_filename = file name(if its blank, the title of the video will be set.)
+w_download = download
+w_get_videoinfo = Get video information
+w_download_range = Download with time specification
+w_only_voice = audio only
+w_embed_thumbnail = embed thumbnails
+w_error_occured = An error has occurred
+
+#widget_error_message
+we_error = Error
+we_input_url = Please enter URL.
+we_specify_folder = Please specify a folder to save the file.
+we_cancel = cancel
+
+w_prepare = preparing
+w_downloading_video = video :
+w_downloading_sound = sound :
+w_downloading = downloading
+w_left = left
+w_processing = processing
+w_comp_download = download complete
+w_download_comp = download is complete!
+
+#EditFilename
+ef_edit_filename = edit filename templates
+ef_apply = apply
+ef_title = title
+ef_creator = content creator name
+ef_creator_id = content creator ID
+ef_upload_date = upload date
+ef_width_videosize = video size width
+ef_height_videosize = video vize height
+ef_domain = domain
+ef_playlist_name = playlist name
+ef_playlist_num = playlist number
+ef_clear = clear
+
+#QuickMode
+qm_download = download
+qm_quit_quickmode = exit QuickMode
+qm_quit_app = exit app
+
+
+[JP]
+#Change_Language_MessageBox
+CLM_title = 変更を適用
+CLM_message = 変更を適用するにはアプリの再起動が必要です。
+CLM_main_message = 再起動しますか？
+CLM_option1 = キャンセル
+CLM_option2 = 再起動
+
+#Update_MessageBox
+UpM_title = アップデート
+UpM_message = 新しいバージョン：
+UpM_main_message = ダウンロードしますか？
+UpM_option1 = キャンセル
+UpM_option2 = ダウンロード
+UpM_option3 = GitHubへ
+
+#Uninstall_MessageBox
+UnM_title = アンインストール
+UnM_message = 本当にアンインストールしますか？
+UnM_option1 = キャンセル
+UnM_option2 = アンインストール
+
+#Menu_Bar
+MB_option = 設定
+MB_cookie = Cookie設定
+MB_cookie_none = なし
+MB_language = 言語設定
+
+#ここからは基本的に変更しないでください
+MB_lang_EN = English
+MB_lang_JP = 日本語
+MB_lang_KR =
+#ここまでは基本的に変更しないでください
+
+MB_view = 表示
+MB_theme = テーマ
+MB_theme_system = システム(メニューバーは再起動時反映)
+MB_theme_dark = ダーク
+MB_theme_light = ライト
+MB_theme_edit = テーマエディタを開く
+
+MB_link = リンクを開く
+MB_link_niconico = ニコニコ動画
+
+MB_beta = ベータ機能
+MB_quickmode = クイックモード
+
+MB_others = その他
+MB_uninstall = アンインストール
+
+#widget
+w_paste = ペースト
+w_savefolder = 保存先フォルダ
+w_browse = 参照
+w_edit = 編集
+w_save_filename = 保存ファイル名(空白ならタイトル)
+w_download = ダウンロード
+w_get_videoinfo = 動画情報の取得
+w_download_range = 範囲指定でダウンロード
+w_only_voice = 音声のみダウンロード
+w_embed_thumbnail = サムネイルを埋め込む
+w_error_occured = エラーが発生しました
+
+#widget_error_message
+we_error = エラー
+we_input_url = URLを入力してください
+we_specify_folder = 保存フォルダを指定してください
+we_cancel = キャンセル
+
+w_prepare = 準備中
+w_downloading_video = 動画
+w_downloading_sound = 音声
+w_downloading = ダウンロード中：
+w_left = 残り容量：
+w_processing = 処理中
+w_comp_download = ダウンロード完了
+w_download_comp = ダウンロードが完了しました
+
+#EditFilename
+ef_edit_filename = ファイル名テンプレートの編集
+ef_apply = 適用
+ef_title = タイトル
+ef_creator = 投稿者
+ef_creator_id = 投稿者ID
+ef_upload_date = 投稿日
+ef_width_videosize = 動画サイズ縦
+ef_height_videosize = 動画サイズ横
+ef_domain = サイトドメイン
+ef_playlist_name = プレイリスト名
+ef_playlist_num = プレイリスト内番号
+ef_clear = クリア
+
+#QuickMode
+qm_download = ダウンロード
+qm_quit_quickmode = クイックモードを終了する
+qm_quit_app = アプリを終了する
+
+[KR]
+#ここの変数を韓国語に置き換えていってください。
+#文法の違いで不自然になる場合はissue投げていただければ対応します。
+#Change_Language_MessageBox
+CLM_title = 変更を適用
+CLM_message = 変更を適用するにはアプリの再起動が必要です。
+CLM_main_message = 再起動しますか？
+CLM_option1 = キャンセル
+CLM_option2 = 再起動
+
+#Update_MessageBox
+UpM_title = アップデート
+UpM_message = 新しいバージョン：
+UpM_main_message = ダウンロードしますか？
+UpM_option1 = キャンセル
+UpM_option2 = ダウンロード
+UpM_option3 = GitHubへ
+
+#Uninstall_MessageBox
+UnM_title = アンインストール
+UnM_message = 本当にアンインストールしますか？
+UnM_option1 = キャンセル
+UnM_option2 = アンインストール
+
+#Menu_Bar
+MB_option = 設定
+MB_cookie = Cookie設定
+MB_cookie_none = なし
+MB_language = 言語設定
+
+#ここからは基本的に変更しないでください
+MB_lang_EN = English
+MB_lang_JP = 日本語
+MB_lang_KR =
+#ここまでは基本的に変更しないでください
+
+MB_view = 表示
+MB_theme = テーマ
+MB_theme_system = システム(メニューバーは再起動時反映)
+MB_theme_dark = ダーク
+MB_theme_light = ライト
+MB_theme_edit = テーマエディタを開く
+
+MB_link = リンクを開く
+MB_link_niconico = ニコニコ動画
+
+MB_beta = ベータ機能
+MB_quickmode = クイックモード
+
+MB_others = その他
+MB_uninstall = アンインストール
+
+#widget
+w_paste = ペースト
+w_savefolder = 保存先フォルダ
+w_browse = 参照
+w_edit = 編集
+w_save_filename = 保存ファイル名(空白ならタイトル)
+w_download = ダウンロード
+w_get_videoinfo = 動画情報の取得
+w_download_range = 範囲指定でダウンロード
+w_only_voice = 音声のみダウンロード
+w_embed_thumbnail = サムネイルを埋め込む
+w_error_occured = エラーが発生しました
+
+#widget_error_message
+we_error = エラー
+we_input_url = URLを入力してください
+we_specify_folder = 保存フォルダを指定してください
+we_cancel = キャンセル
+
+w_prepare = 準備中
+w_downloading_video = 動画
+w_downloading_sound = 音声
+w_downloading = ダウンロード中：
+w_left = 残り容量：
+w_processing = 処理中
+w_comp_download = ダウンロード完了
+w_download_comp = ダウンロードが完了しました
+
+#EditFilename
+ef_edit_filename = ファイル名テンプレートの編集
+ef_apply = 適用
+ef_title = タイトル
+ef_creator = 投稿者
+ef_creator_id = 投稿者ID
+ef_upload_date = 投稿日
+ef_width_videosize = 動画サイズ縦
+ef_height_videosize = 動画サイズ横
+ef_domain = サイトドメイン
+ef_playlist_name = プレイリスト名
+ef_playlist_num = プレイリスト内番号
+ef_clear = クリア
+
+#QuickMode
+qm_download = ダウンロード
+qm_quit_quickmode = クイックモードを終了する
+qm_quit_app = アプリを終了する

--- a/main.py
+++ b/main.py
@@ -990,8 +990,7 @@ class QuickMode:
         app.start_download()
 
     def exit(self):
-        sys.exit()
-
+        os._exit(-1)
 
 app = App()
 app.protocol("WM_DELETE_WINDOW", lambda: app.write_config(False))

--- a/main.py
+++ b/main.py
@@ -89,19 +89,101 @@ class App(ctk.CTk):
         self.set_submenu_color(self.appearances, self.dict_appearance, self.appearance)
         self.set_submenu_color(self.cookies, self.dict_browser, self.browser)
 
-    def check_version(self, this_version):
+    def get_latest_version(self):
+        #apiでバージョンを取得
         r = requests.get(
             "https://api.github.com/repos/okata-t/yt-dlp_GUI/releases/latest"
         )
-
-        # API呼び出し上限の場合、スクレイピングしてバージョンを取得
         try:
             latest_version = r.json()["tag_name"]
+        #api呼び出し上限の際、スクレイピングでバージョンを取得
         except KeyError:
             url = "https://github.com/okata-t/yt-dlp_GUI/releases/latest"
             response = requests.get(url)
             soup = BeautifulSoup(response.text, "html.parser")
             latest_version = soup.find(class_="d-inline mr-3").text[11:]
+        return latest_version
+
+
+    def get_release_note(self, url):
+    #スクレイピングしたtxtの保存場所を指定
+        log_file = "log.txt"
+
+        #key→辞書型変換の際に必要な変数を定義
+        Mode = 1
+        value = ""
+        dic = {}
+
+        #logファイルが0バイト、またはアプデ前の状態だった場合はスクレイピングを行う
+        latest_version = self.get_latest_version()
+
+        if os.stat(log_file).st_size == 0 or version.parse(self.this_log_version) < version.parse(latest_version):
+            #logのバージョンを更新
+            self.this_log_version = latest_version
+            config["Option"]["log_version"] = self.this_log_version
+
+            #releasesのページ数を取得
+            response = requests.get(url)
+            soup = BeautifulSoup(response.text, "html.parser")
+            page = soup.find_all(class_="pagination")
+            for page in page:
+                page_num = int(page.text[-6:-5])
+                break
+
+            #log.txtの中身を0バイトにして初期化
+            with open(log_file, mode="w") as f:
+                f.truncate(0)
+
+            #releasesのバージョン・変更履歴をtxtで取得
+            for i in range(page_num):
+                url_page_num = url + "?page=" + str(i+1)
+                response = requests.get(url_page_num)
+                soup = BeautifulSoup(response.text, "html.parser")
+                note = soup.find_all(class_="Box-body")
+
+                for note in note:
+                    # バージョンと変更履歴の要素を抽出
+                    versions = note.find_all(class_="Link--primary Link")
+                    changes = note.find_all(class_="markdown-body my-3")
+
+                    for ver in versions:
+                        with open(log_file, mode='a', encoding='utf-8') as f:
+                            f.write(ver.text + "\n")
+
+                    for change in changes:
+                        with open(log_file, mode='a', encoding='utf-8') as f:
+                            f.write(change.text + "\n")
+                            f.write("\n")
+                            f.write("---\n")
+
+            #大量に付随してくる余計なヌル文字を削除。ついでに「latest」表記も削除
+            with open(log_file, 'r+', encoding="UTF-8") as f:
+                lines = f.readlines()
+                f.seek(0)
+                f.truncate()
+                lines_to_delete = [5, 11]
+                for i, line in enumerate(lines):
+                    if i not in lines_to_delete and line.strip():
+                        f.write(line)
+
+        #バージョン・変更履歴をtxtから辞書型に変換
+        with open('log.txt', encoding="utf-8") as f:
+            for line in f:
+                if line == "---\n":
+                    dic[key] = value
+                    value = ""
+                    Mode = 1
+                else:
+                    if Mode == 1:
+                        key = line.strip()
+                        Mode = 0
+                    else:
+                        value += line
+
+        return dic
+
+    def check_version(self, this_version):
+        latest_version = self.get_latest_version()
 
         if version.parse(this_version) < version.parse(latest_version):
             msg = CTkMessagebox.CTkMessagebox(
@@ -306,6 +388,7 @@ class App(ctk.CTk):
                 if str(self.cmb_resoluion.get()) != _("最高画質")
                 else "best"
             )
+            config["Option"]["log_version"] = self.this_log_version
             config.write(f)
         if isQuick:
             self.withdraw()
@@ -325,6 +408,7 @@ class App(ctk.CTk):
                 if config["Option"]["resolution"] != "best"
                 else _("最高画質")
             )
+            self.this_log_version = config["Option"]["log_version"]
         except KeyError:
             fix_config()
             self.load_option()

--- a/scraping.py
+++ b/scraping.py
@@ -1,0 +1,42 @@
+import requests
+from bs4 import BeautifulSoup
+
+def get_release_note(url):
+    # releasesのページ数を取得
+    response = requests.get(url)
+    soup = BeautifulSoup(response.text, "html.parser")
+    page = soup.find_all(class_="pagination")
+    for page in page:
+        page_num = int(page.text[-6:-5])
+        break
+
+    # バージョンと変更履歴を直接辞書型に変換
+    releases = {}
+    for i in range(page_num):
+        url_page_num = url + "?page=" + str(i+1)
+        response = requests.get(url_page_num)
+        soup = BeautifulSoup(response.text, "html.parser")
+        note = soup.find_all(class_="Box-body")
+
+        for note in note:
+            # バージョンと変更履歴の要素を抽出
+            versions = note.find_all(class_="Link--primary Link")
+            changes = note.find_all(class_="markdown-body my-3")
+
+            # 最初のバージョンのみ取得し、変更履歴を結合
+            version = versions[0].text.strip()
+            changes = "\n".join([change.text.strip() for change in changes])
+            changes = changes.replace("\n\n", "\n")
+            releases[version] = changes
+
+    return releases
+
+if __name__ == "__main__":
+    url = "https://github.com/okata-t/yt-dlp_GUI/releases"
+    result = get_release_note(url)
+
+    keys = list(result.keys())
+    for i in range(len(result)):
+        key = keys[i]
+        value = result[key]
+        print(keys[i] + "\n" + value)

--- a/scraping_2.py
+++ b/scraping_2.py
@@ -1,0 +1,92 @@
+import os
+import requests
+from packaging import version
+from bs4 import BeautifulSoup
+
+def get_release_note(url):
+    #スクレイピングしたtxtの保存場所を指定
+    log_file = "log.txt"
+
+    #key→辞書型変換の際に必要な変数を定義
+    Mode = 1
+    value = ""
+    dic = {}
+
+    #logファイルが0バイト、またはアプデ前の状態だった場合はスクレイピングを行う
+    this_version = "2.6.1"
+    latest_log_version = "2.6.1"
+
+    if os.stat(log_file).st_size == 0 or version.parse(this_version) < version.parse(latest_log_version):
+        #releasesのページ数を取得
+        response = requests.get(url)
+        soup = BeautifulSoup(response.text, "html.parser")
+        page = soup.find_all(class_="pagination")
+        for page in page:
+            page_num = int(page.text[-6:-5])
+            break
+
+        #log.txtの中身を0バイトにして初期化
+        with open(log_file, mode="w") as f:
+            f.truncate(0)
+
+        #releasesのバージョン・変更履歴をtxtで取得
+        for i in range(page_num):
+            url_page_num = url + "?page=" + str(i+1)
+            response = requests.get(url_page_num)
+            soup = BeautifulSoup(response.text, "html.parser")
+            note = soup.find_all(class_="Box-body")
+
+            for note in note:
+                # バージョンと変更履歴の要素を抽出
+                versions = note.find_all(class_="Link--primary Link")
+                changes = note.find_all(class_="markdown-body my-3")
+
+                for ver in versions:
+                    with open(log_file, mode='a', encoding='utf-8') as f:
+                        f.write(ver.text + "\n")
+
+                for change in changes:
+                    with open(log_file, mode='a', encoding='utf-8') as f:
+                        f.write(change.text + "\n")
+                        f.write("\n")
+                        f.write("---\n")
+
+        #大量に付随してくる余計なヌル文字を削除。ついでに「latest」表記も削除
+        with open(log_file, 'r+', encoding="UTF-8") as f:
+            lines = f.readlines()
+            f.seek(0)
+            f.truncate()
+            lines_to_delete = [5, 11]
+            for i, line in enumerate(lines):
+                if i not in lines_to_delete and line.strip():
+                    f.write(line)
+
+    #バージョン・変更履歴をtxtから辞書型に変換
+    with open('log.txt', encoding="utf-8") as f:
+        for line in f:
+            if line == "---\n":
+                dic[key] = value
+                value = ""
+                Mode = 1
+            else:
+                if Mode == 1:
+                    key = line.strip()
+                    Mode = 0
+                else:
+                    value += line
+
+    return dic
+
+if __name__ == "__main__":
+    url = "https://github.com/okata-t/yt-dlp_GUI/releases"
+    releases = get_release_note(url)
+    print(releases)
+
+    """
+    #辞書型からの文字取り出しプログラム例
+    keys = list(releases.keys())
+    for i in range(len(releases)):
+        key = keys[i]
+        value = releases[key]
+        print(keys[i] + "\n" + value)
+    """

--- a/version.ini
+++ b/version.ini
@@ -1,2 +1,2 @@
 [Version]
-version=v2.4.0
+version=v2.3.0


### PR DESCRIPTION
動作試験用にscraping_2.pyを追加しています。
scraping.pyはlogファイルを介さずに直接リリースノートを取得しているので単純なプログラムですが、毎回スクレイピングをしているのでサーバーへの負荷的には少し不健全かもしれません。